### PR TITLE
Update to work with Cesium 1.59

### DIFF
--- a/lib/custom/custom-sensor-volume-fs.glsl
+++ b/lib/custom/custom-sensor-volume-fs.glsl
@@ -61,9 +61,9 @@ vec4 shade(bool isOnBoundary)
     return getColor(u_sensorRadius, v_positionEC);
 }
 
-float ellipsoidSurfaceFunction(czm_ellipsoid ellipsoid, vec3 point)
+float ellipsoidSurfaceFunction(vec3 point)
 {
-    vec3 scaled = ellipsoid.inverseRadii * point;
+    vec3 scaled = czm_ellipsoidInverseRadii * point;
     return dot(scaled, scaled) - 1.0;
 }
 
@@ -72,8 +72,7 @@ void main()
     vec3 sensorVertexWC = czm_model[3].xyz;      // (0.0, 0.0, 0.0) in model coordinates
     vec3 sensorVertexEC = czm_modelView[3].xyz;  // (0.0, 0.0, 0.0) in model coordinates
 
-    czm_ellipsoid ellipsoid = czm_getWgs84EllipsoidEC();
-    float ellipsoidValue = ellipsoidSurfaceFunction(ellipsoid, v_positionWC);
+    float ellipsoidValue = ellipsoidSurfaceFunction(v_positionWC);
 
     // Occluded by the ellipsoid?
 	if (!u_showThroughEllipsoid)
@@ -86,7 +85,7 @@ void main()
 	    }
 
 	    // Discard if in the sensor's shadow
-	    if (inSensorShadow(sensorVertexWC, ellipsoid, v_positionWC))
+	    if (inSensorShadow(sensorVertexWC, v_positionWC))
 	    {
 	        discard;
 	    }

--- a/lib/sensor-volume.glsl
+++ b/lib/sensor-volume.glsl
@@ -1,10 +1,10 @@
 uniform vec4 u_intersectionColor;
 uniform float u_intersectionWidth;
 
-bool inSensorShadow(vec3 coneVertexWC, czm_ellipsoid ellipsoidEC, vec3 pointWC)
+bool inSensorShadow(vec3 coneVertexWC, vec3 pointWC)
 {
     // Diagonal matrix from the unscaled ellipsoid space to the scaled space.    
-    vec3 D = ellipsoidEC.inverseRadii;
+    vec3 D = czm_ellipsoidInverseRadii;
 
     // Sensor vertex in the scaled ellipsoid space
     vec3 q = D * coneVertexWC;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "cesium"
   ],
   "dependencies": {
-    "cesium": "1.32.1",
+    "cesium": "1.59",
     "requirejs": "^2.3.3",
     "requirejs-text": "^2.0.15"
   },


### PR DESCRIPTION
The plugin fails in Cesium 1.59 with `RuntimeError: Fragment shader failed to compile.  Compile log: ERROR: 0:2: 'czm_ellipsoid' : syntax error`

`czm_ellipsoid` and thus `czm_ellipsoid.inverseRadii` were replaced by constants in https://github.com/AnalyticalGraphicsInc/cesium/pull/7944.
Use the new `czm_ellipsoidInverseRadii` instead to make the plugin work with Cesium 1.59.